### PR TITLE
fix: handle invalid quantity in shipping calculator

### DIFF
--- a/src/utils/shippingCalculator.ts
+++ b/src/utils/shippingCalculator.ts
@@ -1,7 +1,12 @@
 
-export const calculateShipping = (items: any[]): number => {
+interface ShippingItem {
+  product_type?: string;
+  quantity?: number | string;
+}
+
+export const calculateShipping = (items: ShippingItem[]): number => {
   let totalShipping = 0;
-  
+
   for (const item of items) {
     const productType = item.product_type || 'ETC';
     let shippingCost = 0;
@@ -41,7 +46,9 @@ export const calculateShipping = (items: any[]): number => {
         break;
     }
     
-    totalShipping += shippingCost * item.quantity;
+    // Ensure quantity is a valid non-negative number to avoid NaN in totals
+    const quantity = Number(item.quantity);
+    totalShipping += shippingCost * (isNaN(quantity) ? 1 : Math.max(0, quantity));
   }
   
   return totalShipping;


### PR DESCRIPTION
## Summary
- prevent NaN totals in shipping calculator by validating quantity
- add type-safe interface for shipping items

## Testing
- `pnpm lint` *(fails: Unexpected any and other existing issues)*
- `pnpm exec eslint src/utils/shippingCalculator.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68962064b2908326b178419ca2bb4c16